### PR TITLE
test for NULL to bypass exec filter

### DIFF
--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -261,7 +261,7 @@ pub(crate) async fn handle_request(
                 ErrorKind::PermissionDenied => Response::builder()
                     .status(StatusCode::FORBIDDEN)
                     .body(Body::empty()),
-                ErrorKind::InvalidData => Response::builder()
+                ErrorKind::InvalidInput | ErrorKind::InvalidData => Response::builder()
                     .status(StatusCode::BAD_REQUEST)
                     .body(Body::empty()),
                 ErrorKind::BrokenPipe


### PR DESCRIPTION
as seen in other servers.
Something during lookup seems to handle \0 as InvalidInput already