### PR TITLE
websocket via H2. Also via the Reverse Proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ xml-rs = { version = "0.8", optional = true }
 chrono = { version = "0.4", optional = true }
 #proxy
 deadpool = {version="0.11", features=["unmanaged"], default-features = false, optional = true }
-sha1 = {version="*", optional = true }
-base64 = {version="*", optional = true }
+sha1 = {version="0.6", optional = true } # same as websocket-codec
+base64 = {version="0.13", optional = true } # same as websocket-codec
 
 anyhow = "1.0"
 async-stream-connection = {version="^1.0.1", features=["serde"], optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ xml-rs = { version = "0.8", optional = true }
 chrono = { version = "0.4", optional = true }
 #proxy
 deadpool = {version="0.11", features=["unmanaged"], default-features = false, optional = true }
+sha1 = {version="*", optional = true }
+base64 = {version="*", optional = true }
 
 anyhow = "1.0"
 async-stream-connection = {version="^1.0.1", features=["serde"], optional = true}
@@ -69,7 +71,7 @@ logrot = ["log4rs/background_rotation"]
 fcgi = ["async-fcgi", "async-stream-connection"]
 websocket = ["websocket-codec", "tokio-util", "futures-util/sink", "async-stream-connection"]
 webdav = ["xml-rs", "chrono"]
-proxy = ["hyper/client", "deadpool"]
+proxy = ["hyper/client", "deadpool","sha1","base64"]
 
 [[bin]]
 name = "flash_rust_ws"

--- a/src/dispatch/proxy/cfg.rs
+++ b/src/dispatch/proxy/cfg.rs
@@ -140,17 +140,11 @@ impl From<(&str, u16)> for ProxySocket {
 
         // try to parse the host as a regular IP address first
         if let Ok(addr) = host.parse::<std::net::Ipv4Addr>() {
-            let addr = std::net::SocketAddrV4::new(addr, port);
-            let addr = std::net::SocketAddr::V4(addr);
-
-            return ProxySocket::Ip(addr);
+            return ProxySocket::Ip((addr, port).into());
         }
 
         if let Ok(addr) = host.parse::<std::net::Ipv6Addr>() {
-            let addr = std::net::SocketAddrV6::new(addr, port, 0, 0);
-            let addr = std::net::SocketAddr::V6(addr);
-
-            return ProxySocket::Ip(addr);
+            return ProxySocket::Ip((addr, port).into());
         }
 
         ProxySocket::Dns((host.to_owned(), port))

--- a/src/dispatch/proxy/client.rs
+++ b/src/dispatch/proxy/client.rs
@@ -116,6 +116,7 @@ impl Client {
                 .ok_or(IoError::other("No DNS Address could be obtained"))?
             }
         };
+        log::trace!("connecting to {addr}");
         let io = TcpStream::connect(addr).await?;
 
         match cfg.forward.scheme.as_str() {

--- a/src/dispatch/proxy/test.rs
+++ b/src/dispatch/proxy/test.rs
@@ -48,8 +48,15 @@ fn basic_config() {
         panic!("not proxy");
     }
 }
+#[test]
+fn resolve_dns_later() {
+    use std::net::*;
+    assert!(matches!(ProxySocket::from(("test", 123)), ProxySocket::Dns((s, 123)) if s == "test"));
+    assert!(matches!(ProxySocket::from(("127.0.0.1", 123)), ProxySocket::Ip(SocketAddr::V4(ip4)) if *ip4.ip() == Ipv4Addr::LOCALHOST));
+    assert!(matches!(ProxySocket::from(("::1", 123)), ProxySocket::Ip(SocketAddr::V6(ip6)) if *ip6.ip() == Ipv6Addr::LOCALHOST));
+}
 
-/// send a request to a FCGI mount and return its TcpStream
+/// send a request to a proxy mount and return its TcpStream
 /// (as well as the Task doing the request)
 async fn test_forward(
     mut req: Request<TestBody>,

--- a/src/dispatch/webpath.rs
+++ b/src/dispatch/webpath.rs
@@ -212,22 +212,28 @@ impl<B> Req<B> {
         }))
     }
     #[cfg(feature = "fcgi")]
+    #[inline]
     pub fn version(&self) -> hyper::Version {
         self.parts.version
     }
     #[cfg(feature = "fcgi")]
+    #[inline]
     pub fn extensions(&self) -> &hyper::http::Extensions {
         &self.parts.extensions
     }
+    #[inline]
     pub fn is_dir_req(&self) -> bool {
         self.parts.uri.path().as_bytes().last() == Some(&b'/')
     }
+    #[inline]
     pub fn query(&self) -> Option<&str> {
         self.parts.uri.query()
     }
+    #[inline]
     pub fn method(&self) -> &hyper::Method {
         &self.parts.method
     }
+    #[inline]
     pub fn headers(&self) -> &hyper::HeaderMap<hyper::header::HeaderValue> {
         &self.parts.headers
     }

--- a/src/dispatch/websocket.rs
+++ b/src/dispatch/websocket.rs
@@ -16,6 +16,15 @@ use crate::{
     dispatch::{upgrades::MyUpgraded, webpath::Req},
 };
 
+fn check_h2_ws(parts: &hyper::http::request::Parts) -> bool {
+    //https://www.rfc-editor.org/rfc/rfc8441.html
+    parts.extensions.get::<hyper::ext::Protocol>().is_some_and(|proto|proto.as_str() == "websocket")
+    && !parts.headers.contains_key(header::UPGRADE)
+    && !parts.headers.contains_key(header::CONNECTION)
+    //do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields
+    && parts.headers.get(header::SEC_WEBSOCKET_VERSION).is_some_and(|v|v=="13")
+}
+
 pub async fn upgrade(
     req: Req<IncomingBody>,
     ws: &Websocket,
@@ -28,31 +37,70 @@ pub async fn upgrade(
         *res.status_mut() = StatusCode::NOT_FOUND;
         return Ok(res);
     }
-    match *req.method() {
-        hyper::Method::GET => {}
-        hyper::Method::OPTIONS => {
-            res.headers_mut()
-                .insert(header::ALLOW, header::HeaderValue::from_static("GET"));
-            return Ok(res);
+    let (mut parts, body) = req.into_parts();
+    match parts.version {
+        hyper::Version::HTTP_11 => {
+            //https://www.rfc-editor.org/rfc/rfc6455
+            match parts.method {
+                hyper::Method::GET => {}
+                hyper::Method::OPTIONS => {
+                    res.headers_mut()
+                        .insert(header::ALLOW, header::HeaderValue::from_static("GET"));
+                    return Ok(res);
+                }
+                _ => {
+                    *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+                    return Ok(res);
+                }
+            }
+            let ws_accept = if let Ok(req) = ClientRequest::parse(|name| {
+                let h = parts.headers.get(name)?;
+                h.to_str().ok()
+            }) {
+                req.ws_accept()
+            } else {
+                return Err(IoError::new(ErrorKind::InvalidData, "wrong WS update"));
+            };
+
+            let headers = res.headers_mut();
+            headers.insert(
+                header::UPGRADE,
+                header::HeaderValue::from_static("websocket"),
+            );
+            headers.insert(
+                header::CONNECTION,
+                header::HeaderValue::from_static("Upgrade"),
+            );
+            headers.insert(
+                header::SEC_WEBSOCKET_ACCEPT,
+                header::HeaderValue::from_str(&ws_accept).unwrap(),
+            );
+            *res.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+        }
+        hyper::Version::HTTP_2 => {
+            //https://www.rfc-editor.org/rfc/rfc8441.html
+            match parts.method {
+                hyper::Method::CONNECT => {}
+                hyper::Method::OPTIONS => {
+                    res.headers_mut()
+                        .insert(header::ALLOW, header::HeaderValue::from_static("CONNECT"));
+                    return Ok(res);
+                }
+                _ => {
+                    *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+                    return Ok(res);
+                }
+            }
+            if !check_h2_ws(&parts) {
+                return Err(IoError::new(ErrorKind::InvalidData, "wrong WS update"));
+            }
+            *res.status_mut() = StatusCode::OK;
         }
         _ => {
-            *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+            *res.status_mut() = StatusCode::HTTP_VERSION_NOT_SUPPORTED;
             return Ok(res);
         }
     }
-
-    let (parts, body) = req.into_parts();
-    let req = hyper::Request::from_parts(parts, body);
-
-    let ws_accept = if let Ok(req) = ClientRequest::parse(|name| {
-        let h = req.headers().get(name)?;
-        h.to_str().ok()
-    }) {
-        req.ws_accept()
-    } else {
-        return Err(IoError::new(ErrorKind::InvalidData, "wrong WS update"));
-    };
-
     //TODO Sec-WebSocket-Protocol
     //TODO Sec-WebSocket-Extensions
 
@@ -61,10 +109,11 @@ pub async fn upgrade(
 
     let header = if forward_header {
         error!("forwarding header...");
-        Some(req.headers().clone())
+        Some(core::mem::take(&mut parts.headers))
     } else {
         None
     };
+    let req = hyper::Request::from_parts(parts, body);
     tokio::task::spawn(async move {
         match hyper::upgrade::on(req).await {
             Ok(upgraded) => {
@@ -75,21 +124,6 @@ pub async fn upgrade(
         }
     });
 
-    *res.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
-
-    let headers = res.headers_mut();
-    headers.insert(
-        header::UPGRADE,
-        header::HeaderValue::from_static("websocket"),
-    );
-    headers.insert(
-        header::CONNECTION,
-        header::HeaderValue::from_static("Upgrade"),
-    );
-    headers.insert(
-        header::SEC_WEBSOCKET_ACCEPT,
-        header::HeaderValue::from_str(&ws_accept).unwrap(),
-    );
     Ok(res)
 }
 
@@ -288,21 +322,18 @@ mod tests {
         //as it has no associated connection
         let (l, a) = local_socket_pair().await?;
 
-        let mut listening_ifs = std::collections::HashMap::new();
-        let mut cfg = HostCfg::new(l.into_std()?);
-        let mut vh = VHost::new(a);
-        vh.paths.insert(
-            Utf8PathBuf::from("a"),
+        let _s = crate::tests::prep_test_server(
+            l,
+            a,
             WwwRoot {
                 mount: UseCase::Websocket(ws_cfg),
                 header: None,
                 auth: None,
             },
-        );
-        cfg.default_host = Some(vh);
-        listening_ifs.insert(a, cfg);
-
-        let _s = crate::prepare_hyper_servers(listening_ifs).await?;
+            #[cfg(feature = "tlsrust")]
+            None,
+        )
+        .await;
 
         let mut test = tokio::net::TcpStream::connect(a).await?;
         test.write_all(b"GET /a HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n\r\n").await?;
@@ -359,5 +390,138 @@ mod tests {
         Opcode Binary + Opcode Close
          */
         assert_eq!(vec, b"\x82\x04answ\x88\0");
+    }
+    #[cfg(any(feature = "tlsrust", feature = "tlsnative"))]
+    #[tokio::test]
+    async fn as_sock_h2() {
+        use crate::tests::create_tls_cfg;
+        let (l, a) = local_socket_pair().await.unwrap();
+
+        let ws_cfg = Websocket {
+            assock: Addr::Inet(a),
+            forward_header: false,
+        };
+
+        let t: JoinHandle<Result<(), std::io::Error>> = tokio::spawn(async move {
+            let (mut s, _a) = l.accept().await?;
+
+            let mut buf = [0u8; 12];
+            let i = s.read_exact(&mut buf).await?;
+            assert_eq!(&buf[..i], b"test message");
+
+            s.write_all(b"answ").await?;
+            Ok(())
+        });
+
+        let (mut config, tlscfg) = create_tls_cfg().await;
+
+        let (l, a) = local_socket_pair().await.unwrap();
+
+        let _s = crate::tests::prep_test_server(
+            l,
+            a,
+            WwwRoot {
+                mount: UseCase::Websocket(ws_cfg),
+                header: None,
+                auth: None,
+            },
+            Some(tlscfg),
+        )
+        .await;
+
+        let stream = tokio::net::TcpStream::connect(a).await.unwrap();
+        #[cfg(feature = "tlsrust")]
+        let mut stream = {
+            let dnsname =
+                tokio_rustls::rustls::pki_types::ServerName::try_from("example.com").unwrap();
+            config.alpn_protocols.push(b"h2".to_vec());
+            let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(config));
+            connector.connect(dnsname, stream).await.unwrap()
+        };
+
+        let h = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n\0\0\0\x04\0\0\0\0\0";
+        //                   PREFACE------------------------- Len (0)---  TypFlag ID-------------
+
+        stream.write_all(h).await.unwrap();
+
+        let req = b"\0\0A\x01\x04\0\0\0\x01B\x87\xbd\xabN\x9c\x17\xb7\xffD\x82`\x7fA\x8c\x9d)\xacK\xccz\x07T\xcb\x9e\xc9\xbf\x87@\x87\xb9]\x87I\xc8z?\x87\xf0X\xd0ru*\x7f@\x8fAH\xb7\x82\xc6\x83\x93\xa9R\xb7r\xd8\x83\x1e\xaf\x82\x0b?";
+        /*headers = [
+            (':method', 'CONNECT'),
+            (':path', '/a'),
+            (':authority', SERVER_NAME),
+            (':scheme', 'https'),
+            (':protocol','websocket'),
+            ('sec-websocket-version','13')
+        ]*/
+        stream.write_all(req).await.unwrap();
+
+        //                                        HEADERS + END_HEADERS
+        //                                        :status = 200
+        let mut buf = [0u8; 180];
+        let mut ack = false;
+        loop {
+            println!("wait1");
+            stream.read_exact(&mut buf[..4]).await.unwrap();
+            assert_eq!(buf[0], 0);
+            assert_eq!(buf[1], 0);
+            assert_ne!(buf[3], 3); //not reset_stream
+            assert_ne!(buf[3], 7); //not goaway
+            let off = buf[2] as usize + 5;
+            println!("wait2");
+            stream.read_exact(&mut buf[4..off + 4]).await.unwrap();
+            println!("got {:?}", &buf[..off + 4]);
+            if !ack && buf[3] == 4 && buf[4] == 0 {
+                //Settings
+                //SETTINGS_ENABLE_CONNECT_PROTOCOL (8) = 1
+                assert!(buf[4 + 5..].chunks(6).any(|kv| kv == b"\0\x08\0\0\0\x01"));
+
+                println!("ack");
+                let req = b"\0\0\0\x04\x01\0\0\0\0";
+                stream.write_all(req).await.unwrap();
+                ack = true;
+            }
+            if buf[3] == 1 && buf[4] == 4 {
+                //Header + END_HEADERS
+                assert_eq!(buf[9], 0x88); //:status = 200
+                println!("done");
+                break;
+            }
+        }
+        //DATA
+        //WebSocket Data
+        //                                        DATA + END_STREAM
+        //                                        WebSocket Data
+        //DATA + END_STREAM
+        //WebSocket Data
+
+        /*WebSocket
+            1... .... = Fin: True
+            .000 .... = Reserved: 0x0
+            .... 0001 = Opcode: Text (1)
+            1... .... = Mask: True
+            .000 1100 = Payload length: 12
+            Masking-Key: e17e8eb9
+            Masked payload
+            Payload
+        JavaScript Object Notation
+        Line-based text data
+            test message*/
+        stream.write_all(b"\0\0\x12\0\0\0\0\0\x01\x81\x8c\xe1\x7e\x8e\xb9\x95\x1b\xfd\xcd\xc1\x13\xeb\xca\x92\x1f\xe9\xdc")
+            .await
+            .unwrap();
+
+        stream
+            .read_exact(&mut buf[..6 + 5 + 4 + 2 + 5 + 4])
+            .await
+            .unwrap();
+
+        t.await.unwrap().unwrap();
+        /*
+        Opcode Binary + Opcode Close
+         */
+        assert_eq!(
+            &buf[..6 + 5 + 4 + 2 + 5 + 4],
+            b"\0\0\x06\0\0\0\0\0\x01\x82\x04answ\0\0\x02\0\0\0\0\0\x01\x88\0"
+        );
     }
 }


### PR DESCRIPTION
- h2 Support for the websocket mount
- proxy:
   - h2 extended connect support
   - convert between extended connect and upgrade
      H2 -> http1.1
      Http 1.1 -> h2