### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.1](https://github.com/User65k/flash_rust_ws/compare/v0.5.0...v0.5.1) - 2024-09-04
+
+### Other
+- websocket via H2. Also via the Reverse Proxy ([#46](https://github.com/User65k/flash_rust_ws/pull/46))
+- use upload-rust-binary-action
+- Create release-plz action

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_rust_ws"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 license = "AGPL-3.0"


### PR DESCRIPTION
## 🤖 New release
* `flash_rust_ws`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/User65k/flash_rust_ws/compare/v0.5.0...v0.5.1) - 2024-09-04

### Other
- websocket via H2. Also via the Reverse Proxy ([#46](https://github.com/User65k/flash_rust_ws/pull/46))
- use upload-rust-binary-action
- Create release-plz action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).