### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/User65k/flash_rust_ws/compare/v0.5.1...v0.5.2) - 2026-03-11
+
+### Other
+
+- Updates and better Errors ([#51](https://github.com/User65k/flash_rust_ws/pull/51))
+- Update GitHub Actions workflow permissions
+- dont be more restrictive than a test ([#49](https://github.com/User65k/flash_rust_ws/pull/49))
+
 ## [0.5.1](https://github.com/User65k/flash_rust_ws/compare/v0.5.0...v0.5.1) - 2024-09-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_rust_ws"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 license = "AGPL-3.0"


### PR DESCRIPTION



## 🤖 New release

* `flash_rust_ws`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.2](https://github.com/User65k/flash_rust_ws/compare/v0.5.1...v0.5.2) - 2026-09-14

### Other

- Re ([#52](https://github.com/User65k/flash_rust_ws/pull/52))
- Updates and better Errors ([#51](https://github.com/User65k/flash_rust_ws/pull/51))
- Update GitHub Actions workflow permissions
- dont be more restrictive than a test ([#49](https://github.com/User65k/flash_rust_ws/pull/49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).